### PR TITLE
Coffee with ice on top

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 sudo: false
 
 node_js:
-  - "0.10"
-  - "0.12"
   - "iojs"
 
 after_success:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## v1.1.0: 2016-08-08
+## v1.0.0: 2015-09-17
 
-- Update to coffee-script@1.10.0
-- Tighten coffee-script version restriction since it doesn't conform to semver
-
-## v1.0.0: 2015-08-04
-
-- Unchanged
-- Stable release
-
-## v0.1.0: 2015-06-25
-
-- Updated dependencies
+- Coffee with ice

--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
-# jstransformer-coffee-script
+# jstransformer-iced-coffee-script
 
-[CoffeeScript](http://coffeescript.org) support for [JSTransformers](http://github.com/jstransformers).
-
-[![Build Status](https://img.shields.io/travis/jstransformers/jstransformer-coffee-script/master.svg)](https://travis-ci.org/jstransformers/jstransformer-coffee-script)
-[![Coverage Status](https://img.shields.io/coveralls/jstransformers/jstransformer-coffee-script/master.svg)](https://coveralls.io/r/jstransformers/jstransformer-coffee-script?branch=master)
-[![Dependency Status](https://img.shields.io/david/jstransformers/jstransformer-coffee-script/master.svg)](http://david-dm.org/jstransformers/jstransformer-coffee-script)
-[![NPM version](https://img.shields.io/npm/v/jstransformer-coffee-script.svg)](https://www.npmjs.org/package/jstransformer-coffee-script)
+[IcedCoffeeScript](http://maxtaco.github.io/coffee-script/) support for [JSTransformers](http://github.com/jstransformers).
 
 ## Installation
 
-    npm install jstransformer-coffee-script
+    npm install jstransformer-iced-coffee-script
 
 ## API
 
 ```js
-var coffee = require('jstransformer')(require('jstransformer-coffee'))
+var coffee = require('jstransformer')(require('jstransformer-iced-coffee-script'))
 
 coffee.render('n = 42', {bare: true}).body
 //=> var n; n = 42;

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var coffee = require('iced-coffee-script');
+var coffee = require('iced-coffee-script-3');
 var merge = require('merge');
 
-exports.name = 'iced-coffee-script';
+exports.name = 'iced-coffee-script-3';
 exports.inputFormats = ['coffee', 'coffee-script'];
 exports.outputFormat = 'js';
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var coffee = require('coffee-script');
+var coffee = require('iced-coffee-script');
 var merge = require('merge');
 
-exports.name = 'coffee-script';
+exports.name = 'iced-coffee-script';
 exports.inputFormats = ['coffee', 'coffee-script'];
 exports.outputFormat = 'js';
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "index.js"
   ],
   "dependencies": {
-    "iced-coffee-script": "^108.0.11",
+    "iced-coffee-script-3": "^110.0.0",
     "merge": "^1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "jstransformer-coffee-script",
-  "version": "1.1.0",
-  "description": "Coffee-Script support for JSTransformers.",
+  "name": "jstransformer-iced-coffee-script",
+  "version": "1.0.0",
+  "description": "Iced-Coffee-Script support for JSTransformers.",
   "keywords": [
     "jstransformer"
   ],
@@ -9,7 +9,6 @@
     "index.js"
   ],
   "dependencies": {
-    "coffee-script": "~1.10.0",
     "merge": "^1.2.0"
   },
   "devDependencies": {
@@ -21,10 +20,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jstransformers/jstransformer-coffee-script.git"
+    "url": "https://github.com/jstransformers/jstransformer-iced-coffee-script.git"
   },
   "author": {
-    "name": "JSTransformers Team",
+    "name": "JSTransformers Team + LazyTyper",
     "url": "http://github.com/orgs/jstransformers/people"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "index.js"
   ],
   "dependencies": {
+    "iced-coffee-script": "^108.0.11",
     "merge": "^1.2.0"
   },
   "devDependencies": {

--- a/test/expected.js
+++ b/test/expected.js
@@ -1,5 +1,31 @@
-var n;
+var search, __iced_k, __iced_k_noop;
 
-n = 42;
+__iced_k = __iced_k_noop = function() {};
 
-console.log(n);
+search = function(keyword, cb) {
+  var host, json, url, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+  __iced_k = __iced_k_noop;
+  ___iced_passed_deferral = iced.findDeferral(arguments);
+  host = "http://search.twitter.com/";
+  url = "" + host + "/search.json?q=" + keyword + "&callback=?";
+  (function(_this) {
+    return (function(__iced_k) {
+      __iced_deferrals = new iced.Deferrals(__iced_k, {
+        parent: ___iced_passed_deferral
+      });
+      $.getJSON(url, __iced_deferrals.defer({
+        assign_fn: (function() {
+          return function() {
+            return json = arguments[0];
+          };
+        })(),
+        lineno: 3
+      }));
+      __iced_deferrals._fulfill();
+    });
+  })(this)((function(_this) {
+    return function() {
+      return cb(json.results);
+    };
+  })(this));
+};

--- a/test/expected.js
+++ b/test/expected.js
@@ -1,17 +1,19 @@
-var search, __iced_k, __iced_k_noop;
+var search;
 
-__iced_k = __iced_k_noop = function() {};
+
 
 search = function(keyword, cb) {
-  var host, json, url, ___iced_passed_deferral, __iced_deferrals, __iced_k;
-  __iced_k = __iced_k_noop;
-  ___iced_passed_deferral = iced.findDeferral(arguments);
-  host = "http://search.twitter.com/";
-  url = "" + host + "/search.json?q=" + keyword + "&callback=?";
-  (function(_this) {
-    return (function(__iced_k) {
-      __iced_deferrals = new iced.Deferrals(__iced_k, {
-        parent: ___iced_passed_deferral
+  var __iced_it, __iced_passed_deferral;
+  __iced_passed_deferral = iced.findDeferral(arguments);
+  __iced_it = (function(_this) {
+    var host, json, url;
+    return function*() {
+      var __iced_deferrals;
+      host = "http://search.twitter.com/";
+      url = host + "/search.json?q=" + keyword + "&callback=?";
+      __iced_deferrals = new iced.Deferrals(__iced_it, {
+        parent: __iced_passed_deferral,
+        funcname: "<anonymous: search>"
       });
       $.getJSON(url, __iced_deferrals.defer({
         assign_fn: (function() {
@@ -21,11 +23,11 @@ search = function(keyword, cb) {
         })(),
         lineno: 3
       }));
-      __iced_deferrals._fulfill();
-    });
-  })(this)((function(_this) {
-    return function() {
+      if (__iced_deferrals.await_exit()) {
+        yield;
+      }
       return cb(json.results);
     };
-  })(this));
+  })(this)();
+  return __iced_it.next();
 };

--- a/test/input.coffee
+++ b/test/input.coffee
@@ -1,2 +1,5 @@
-n = 42
-console.log n
+search = (keyword, cb) ->
+  host = "http://search.twitter.com/"
+  url = "#{host}/search.json?q=#{keyword}&callback=?"
+  await $.getJSON url, defer json
+  cb json.results


### PR DESCRIPTION
The changed are an upgrade from `coffee-script` to `iced-coffee-script`. (http://maxtaco.github.io/coffee-script/). The  `coffee-script` transforming should still work, it's just `coffee-script` with some ice on top.

You can either:

`a)` merge it, but take care of the changes in `package.json` and the `*.md` files. The coffee-script transformer will include with the "ice on top". It should work for all coffee-scripts, and they should be downward compatible to coffee-script without the "ice", because "iced-coffee-script" is just a superset of CoffeeScript.
`b) take over my repository to your jstransformers collection and create a NPM package for it.
*cheers* and take your choice, and after finishing, take your choice, which type of iced coffee you like: http://www.clipartkid.com/iced-coffee-cliparts/ ;-)

An example without `ice`:

``` coffee
serialSearch = (keywords, cb) ->
  result = []
  i = 0
  launch = () ->
    if i < keywords.length
       j = i++
       search keywords[j], cb_generator j
     else
       cb results
  cb_generator = (i) ->
    (json) ->
      results[i] = json
      launch()
  launch()
```

With `ice`:

``` coffee
serialSearch = (keywords, cb) ->
  out = []
  for k,i in keywords
    await search k, defer out[i]
  cb out
```

